### PR TITLE
Avoid function defaults for Node v5

### DIFF
--- a/plugin-wp-base.js
+++ b/plugin-wp-base.js
@@ -33,7 +33,8 @@ module.exports = yeoman.generators.Base.extend({
 		return words.toLowerCase();
 	},
 
-	_namespaceify: function( namespace, client = '' ) {
+	_namespaceify: function( namespace, client ) {
+		client = client || '';
 		if ( '' != client ) {
 			var namespace = namespace.replace( client, '' );
 		}


### PR DESCRIPTION
Older versions of node don't allow function defaults. This is the only thing stopping the package from being compatible with node v5.x, and it's easy to shim.